### PR TITLE
Updated inputs

### DIFF
--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -6,9 +6,8 @@ import os
 @mock.patch(
     "pencil_pusher.input.environ",
     {
-        "INPUT_OWNER_NAME": "o_n",
-        "INPUT_REPOSITORY_NAME": "r_n",
-        "INPUT_PERSONAL_ACCESS_TOKEN": "p_a_t",
+        "GITHUB_REPOSITORY": "o_n/r_n",
+        "INPUT_GITHUB_TOKEN": "gh_t",
         "INPUT_CONFIG_FILE": "c_f",
     },
 )
@@ -21,7 +20,9 @@ def test_input_manager():
 
     assert im.validate()
 
+    # these are provided by the github action
     assert im.get("owner_name") == "o_n"
     assert im.get("repository_name") == "r_n"
-    assert im.get("personal_access_token") == "p_a_t"
+
+    assert im.get("github_token") == "gh_t"
     assert im.get("config_file") == "c_f"


### PR DESCRIPTION
resolves #36 

token is still required but can be user defined as `${{ secrets.GITHUB_TOKEN }}`